### PR TITLE
Adds BMP085 barometer support and logging

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -10,6 +10,7 @@ lib_deps =
   greiman/SdFat@^2.2.3
   jgromes/RadioLib@^6.6.0
   adafruit/Adafruit BMP3XX Library@^2.1.6
+  adafruit/Adafruit BMP085 Library@^1.2.4
   adafruit/Adafruit Unified Sensor@^1.1.15
 
   adafruit/Adafruit BusIO
@@ -29,6 +30,7 @@ lib_deps =
   greiman/SdFat@^2.2.3
   jgromes/RadioLib@^6.6.0
   adafruit/Adafruit BMP3XX Library@^2.1.6
+  adafruit/Adafruit BMP085 Library@^1.2.4
   adafruit/Adafruit Unified Sensor@^1.1.15
 
   adafruit/Adafruit BusIO

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -6,6 +6,7 @@
 constexpr uint32_t IMU_HZ   = 400;   // accel
 constexpr uint32_t GYRO_HZ  = 760;   // gyro
 constexpr uint32_t BARO_HZ  = 200;
+constexpr uint32_t BARO2_HZ = 25;
 constexpr uint32_t GNSS_HZ  = 10;
 constexpr uint32_t LORA_HZ  = 2;
 
@@ -39,9 +40,9 @@ constexpr uint8_t LRDY_PIN = 37;
 // ---------- I2C ----------
 #define I2C_BUS Wire
 constexpr uint32_t I2C_HZ = 1000000; // 1 MHz if your wiring allows
-constexpr uint8_t  BMP_CS = 6;
+constexpr uint8_t  BMP_CS = 38;
 constexpr uint32_t BMP_SPI_HZ = 1000000;
-#define BMP_SPI_BUS SPI
+#define BMP_SPI_BUS SPI2
 
 // ---------- LoRa (SX127x-style via RadioLib) ----------
 // FCC Part 97 only (Amateur Radio Service). Not legal for unlicensed/uncontrolled operation.

--- a/src/gnss_ubx.cpp
+++ b/src/gnss_ubx.cpp
@@ -1,6 +1,7 @@
 #include "gnss_ubx.h"
 #include "cfg.h"
 #include "records.h"
+#include <Arduino.h>
 #include <stddef.h>
 #include <string.h>
 

--- a/src/records.h
+++ b/src/records.h
@@ -8,6 +8,7 @@ enum RecordType : uint8_t {
   REC_TIME_ANCHOR  = 0x04, // PPS-to-GNSS anchor (fixed)
   REC_EVENT        = 0x05, // markers (fixed)
   REC_STATS        = 0x06, // drop counters, voltages, etc (fixed)
+  REC_BARO2        = 0x07, // bmp180 (fixed)
 };
 
 #pragma pack(push, 1)
@@ -28,6 +29,14 @@ struct RecImuFast {
 
 struct RecBaro {
   RecHdr   h;        // type=REC_BARO
+  uint32_t t_us;
+  int32_t  press_pa_x10;
+  int16_t  temp_c_x100;
+  uint16_t status;
+};
+
+struct RecBaro2 {
+  RecHdr   h;        // type=REC_BARO2
   uint32_t t_us;
   int32_t  press_pa_x10;
   int16_t  temp_c_x100;

--- a/src/sensors.h
+++ b/src/sensors.h
@@ -19,4 +19,5 @@ public:
   bool begin();
   bool read_imu(ImuSample& out);
   bool read_baro(BaroSample& out);
+  bool read_baro2(BaroSample& out);
 };


### PR DESCRIPTION
Introduces a second barometer (BMP085) via I2C alongside the existing BMP3XX (SPI) and logs its data as a new record type.
- Adds Adafruit BMP085 library and enables BMP085 usage
- Introduces BARO2_HZ (default 25 Hz) to control sampling rate for the second barometer
- Adds new ring buffer path for Baro2 data and corresponding RecBaro2 record type
- Extends sensor interface with read_baro2() and implements BMP085-based readings
- Schedules periodic Baro2 sampling in the main loop and emits RecBaro2 records
- Updates bus/config: BMP_CS and BMP_SPI_BUS adapted for BMP085 on I2C/SPI2
- Minor inclusion tweak to gnss_ubx.cpp for Arduino compatibility