### PR TITLE
Adds remote buzzer control via LoRa commands with configurable duration

### DIFF
--- a/receiver/pi/ground_station/ground_station_server.py
+++ b/receiver/pi/ground_station/ground_station_server.py
@@ -53,6 +53,7 @@ RAD_TO_DEG = 180.0 / math.pi
 LORA_CMD_MAGIC = 0xB1
 LORA_CMD_SD_START = 0x01
 LORA_CMD_SD_STOP = 0x02
+LORA_CMD_BUZZER = 0x03
 LORA_CMD_REPEAT_COUNT = 3
 LORA_CMD_REPEAT_DELAY_S = 0.1
 
@@ -846,11 +847,19 @@ def lora_worker():
             pass
 
 
-def send_lora_command(action):
+def send_lora_command(action, duration_s=None):
     if action == "sd_start":
         payload = bytes([LORA_CMD_MAGIC, LORA_CMD_SD_START])
     elif action == "sd_stop":
         payload = bytes([LORA_CMD_MAGIC, LORA_CMD_SD_STOP])
+    elif action == "buzzer":
+        try:
+            duration = int(duration_s)
+        except (TypeError, ValueError):
+            return False, "Duration must be a number"
+        if duration not in (1, 5, 10, 30):
+            return False, "Duration must be one of 1, 5, 10, 30"
+        payload = bytes([LORA_CMD_MAGIC, LORA_CMD_BUZZER, duration])
     else:
         return False, "Unknown command"
 
@@ -964,7 +973,8 @@ class GroundStationHandler(BaseHTTPRequestHandler):
         if path == "/api/command":
             payload = self._read_json() or {}
             action = payload.get("action")
-            ok, error = send_lora_command(action)
+            duration_s = payload.get("duration_s")
+            ok, error = send_lora_command(action, duration_s)
             if not ok:
                 return self._send_json({"ok": False, "error": error}, status=400)
             return self._send_json({"ok": True})

--- a/receiver/pi/ground_station/static/index.html
+++ b/receiver/pi/ground_station/static/index.html
@@ -46,6 +46,22 @@
           </div>
           <p class="control-status" id="sd-status">Idle</p>
         </div>
+        <div class="control-panel">
+          <span class="label">Buzzer</span>
+          <div class="control-buttons">
+            <div class="control-input">
+              <label for="buzzer-duration">Duration (s)</label>
+              <select id="buzzer-duration" class="control-select">
+                <option value="1">1</option>
+                <option value="5" selected>5</option>
+                <option value="10">10</option>
+                <option value="30">30</option>
+              </select>
+            </div>
+            <button class="control-button" id="buzzer-activate" type="button">Activate buzzer</button>
+          </div>
+          <p class="control-status" id="buzzer-status">Idle</p>
+        </div>
         <a class="ghost-button" href="/map-setup">Offline map setup</a>
       </div>
     </header>

--- a/receiver/pi/ground_station/static/style.css
+++ b/receiver/pi/ground_station/static/style.css
@@ -177,6 +177,35 @@ h1 {
   gap: 8px;
 }
 
+.control-input {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 110px;
+}
+
+.control-input label {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.control-select {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-family: "Space Grotesk", "Trebuchet MS", sans-serif;
+  font-size: 0.82rem;
+  color: var(--ink);
+  background: #fff;
+}
+
+.control-select:focus {
+  outline: 2px solid rgba(30, 111, 92, 0.25);
+  outline-offset: 1px;
+}
+
 .control-button {
   border: none;
   border-radius: 999px;

--- a/receiver/pi/lora_receive_pi.py
+++ b/receiver/pi/lora_receive_pi.py
@@ -192,6 +192,7 @@ CMD_MAGIC = 0xB1
 CMD_ACK = 0x10
 CMD_SD_START = 0x01
 CMD_SD_STOP = 0x02
+CMD_BUZZER = 0x03
 
 class SX1278:
     def __init__(self, spi, nss, rst, dio0):
@@ -449,6 +450,8 @@ def parse_payload(payload):
             cmd_label = "sd_start"
         elif cmd == CMD_SD_STOP:
             cmd_label = "sd_stop"
+        elif cmd == CMD_BUZZER:
+            cmd_label = "buzzer"
         else:
             cmd_label = "unknown"
         return {

--- a/src/lora_link.cpp
+++ b/src/lora_link.cpp
@@ -59,6 +59,7 @@ static constexpr uint8_t LORA_CMD_MAGIC = 0xB1;
 static constexpr uint8_t LORA_CMD_ACK = 0x10;
 static constexpr uint8_t LORA_CMD_SD_START = 0x01;
 static constexpr uint8_t LORA_CMD_SD_STOP = 0x02;
+static constexpr uint8_t LORA_CMD_BUZZER = 0x03;
 static constexpr uint16_t LORA_RX_DONE_FLAG = 0x40;
 static constexpr uint8_t LORA_ACK_REPEAT_COUNT = 3;
 static constexpr uint32_t LORA_ACK_REPEAT_MS = 400;
@@ -140,10 +141,14 @@ bool LoraLink::tx_enabled() const {
   return tx_enabled_;
 }
 
-bool LoraLink::pop_command(LoraCommand& cmd) {
+bool LoraLink::pop_command(LoraCommand& cmd, uint8_t* arg) {
   if (pending_cmd_ == 0) return false;
   cmd = static_cast<LoraCommand>(pending_cmd_);
+  if (arg != nullptr) {
+    *arg = pending_cmd_arg_;
+  }
   pending_cmd_ = 0;
+  pending_cmd_arg_ = 0;
   return true;
 }
 
@@ -627,11 +632,16 @@ bool LoraLink::handle_command_(const uint8_t* data, size_t len) {
   if (len < 2) return false;
   if (data[0] != LORA_CMD_MAGIC) return false;
   const uint8_t cmd = data[1];
-  if (cmd != LORA_CMD_SD_START && cmd != LORA_CMD_SD_STOP) return false;
+  if (cmd == LORA_CMD_BUZZER) {
+    if (len < 3) return false;
+  } else if (cmd != LORA_CMD_SD_START && cmd != LORA_CMD_SD_STOP) {
+    return false;
+  }
 #if DEBUG_MODE
   DBG_PRINTF("lora: cmd rx 0x%02X\n", cmd);
 #endif
   pending_cmd_ = cmd;
+  pending_cmd_arg_ = (cmd == LORA_CMD_BUZZER && len >= 3) ? data[2] : 0;
   return true;
 }
 

--- a/src/lora_link.h
+++ b/src/lora_link.h
@@ -8,6 +8,7 @@ enum class LoraCommand : uint8_t {
   kNone = 0,
   kSdStart = 0x01,
   kSdStop = 0x02,
+  kBuzzer = 0x03,
 };
 
 class LoraLink {
@@ -20,7 +21,7 @@ public:
 
   bool ready() const;
   bool tx_enabled() const;
-  bool pop_command(LoraCommand& cmd);
+  bool pop_command(LoraCommand& cmd, uint8_t* arg = nullptr);
   void queue_command_ack(LoraCommand cmd, bool logging_enabled);
 
   // Cleartext telemetry payload (ASCII, human-decodable):
@@ -101,6 +102,7 @@ private:
   uint8_t tx_buf_[32] = {0};
   bool rx_active_ = false;
   uint8_t pending_cmd_ = 0;
+  uint8_t pending_cmd_arg_ = 0;
   bool ack_pending_ = false;
   uint32_t ack_retry_after_ms_ = 0;
   uint8_t ack_retries_left_ = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1061,14 +1061,30 @@ void loop() {
 
   {
     LoraCommand cmd = LoraCommand::kNone;
-    if (lora.pop_command(cmd)) {
-      if (!buzzer_busy()) {
-        buzzer_start_seq(60, 0, 1, now_ms);
-      }
+    uint8_t cmd_arg = 0;
+    if (lora.pop_command(cmd, &cmd_arg)) {
       if (cmd == LoraCommand::kSdStart) {
+        if (!buzzer_busy()) {
+          buzzer_start_seq(60, 0, 1, now_ms);
+        }
         sd_logging_start();
       } else if (cmd == LoraCommand::kSdStop) {
+        if (!buzzer_busy()) {
+          buzzer_start_seq(60, 0, 1, now_ms);
+        }
         sd_logging_stop();
+      } else if (cmd == LoraCommand::kBuzzer) {
+        uint16_t duration_ms = 0;
+        switch (cmd_arg) {
+          case 1: duration_ms = 1000; break;
+          case 5: duration_ms = 5000; break;
+          case 10: duration_ms = 10000; break;
+          case 30: duration_ms = 30000; break;
+          default: duration_ms = 0; break;
+        }
+        if (duration_ms != 0) {
+          buzzer_start_seq(duration_ms, 0, 1, now_ms);
+        }
       }
       lora.enable_tx(sd_logging_enabled);
       lora.queue_command_ack(cmd, sd_logging_enabled);


### PR DESCRIPTION
Implements LORA_CMD_BUZZER (0x03) command type with duration argument (1, 5, 10, or 30 seconds). Updates ground station server with buzzer command support in send_lora_command() including duration validation. Adds buzzer control panel to web UI with duration dropdown selector and activate button with pending/success/error status display. Updates LoraLink::pop_command() to accept optional arg parameter for command arguments an