### PR TITLE
feat(esp32): add optional SD card bootstrap for future on-device assets

### DIFF
--- a/receiver/esp32-companion/README.md
+++ b/receiver/esp32-companion/README.md
@@ -53,6 +53,7 @@ cp include/config.h.example include/config.h
 - UART pins/baud for your board revision
 - Wi-Fi + host settings if using API/SSE mode
 - auth token if `/api/companion/cmd` is protected
+- optional SD bootstrap (`COMPANION_SD_ENABLE`, `COMPANION_SD_CS_PIN`, `COMPANION_SD_SPI_FREQ`, `COMPANION_SD_SOUND_DIR`) for future sound assets
 - OTA settings (`OTA_ENABLE`, `OTA_HOSTNAME`, `OTA_PORT`, `OTA_PASSWORD`) if using OTA updates
 
 When `OTA_ENABLE=1`, firmware keeps Wi-Fi active even in UART transport mode so OTA

--- a/receiver/esp32-companion/include/config.h.example
+++ b/receiver/esp32-companion/include/config.h.example
@@ -62,6 +62,13 @@
 // Set to 1 to show a quick LCD bring-up test (RGB + text) at boot.
 #define DISPLAY_TEST_SCREEN 1
 
+// Optional SD card bootstrap for future on-device assets (for example: sounds).
+// Set COMPANION_SD_CS_PIN to your board's SD/TF CS pin (or -1 to disable).
+#define COMPANION_SD_ENABLE 0
+#define COMPANION_SD_CS_PIN -1
+#define COMPANION_SD_SPI_FREQ 10000000
+#define COMPANION_SD_SOUND_DIR "/sounds"
+
 // OTA update settings.
 // When enabled, firmware keeps Wi-Fi active even in UART transport mode.
 // First flash should be done over USB, then OTA can be used for updates.

--- a/receiver/esp32-companion/src/app/lvgl_controller.cpp
+++ b/receiver/esp32-companion/src/app/lvgl_controller.cpp
@@ -1,8 +1,10 @@
 #include "lvgl_controller.h"
 
+#include <SD.h>
 #include <esp_heap_caps.h>
 #include <math.h>
 #include <SPI.h>
+#include <string.h>
 
 namespace {
 
@@ -78,6 +80,22 @@ static int32_t mapLinearRange(int32_t value,
 
 #ifndef COMPANION_BAT_ADC_MIN_VALID_MV
 #define COMPANION_BAT_ADC_MIN_VALID_MV 50
+#endif
+
+#ifndef COMPANION_SD_ENABLE
+#define COMPANION_SD_ENABLE 0
+#endif
+
+#ifndef COMPANION_SD_CS_PIN
+#define COMPANION_SD_CS_PIN -1
+#endif
+
+#ifndef COMPANION_SD_SPI_FREQ
+#define COMPANION_SD_SPI_FREQ 10000000
+#endif
+
+#ifndef COMPANION_SD_SOUND_DIR
+#define COMPANION_SD_SOUND_DIR "/sounds"
 #endif
 
 constexpr uint32_t kBatterySampleIntervalMs = COMPANION_BAT_SAMPLE_INTERVAL_MS;
@@ -625,6 +643,7 @@ void LvglController::begin() {
   tft_.init();
   tft_.setRotation(1);
   tft_.fillScreen(TFT_BLACK);
+  initSdStorage();
 
 #if COMPANION_LINK_UART
   pinMode(COMPANION_BAT_ADC_PIN, INPUT);
@@ -705,6 +724,40 @@ void LvglController::updateCompanionBattery() {
   const float vadc = mvAvg / 1000.0f;
   state_.battery.companionVbatV =
       vadc * COMPANION_BAT_ADC_DIVIDER_SCALE * COMPANION_BAT_ADC_CAL_SCALE;
+}
+
+void LvglController::initSdStorage() {
+  sdStorageReady_ = false;
+  sdStorageTotalBytes_ = 0;
+  sdStorageUsedBytes_ = 0;
+
+#if COMPANION_SD_ENABLE
+#if COMPANION_SD_CS_PIN < 0
+  return;
+#else
+  pinMode(COMPANION_SD_CS_PIN, OUTPUT);
+  digitalWrite(COMPANION_SD_CS_PIN, HIGH);
+
+  if (!SD.begin(COMPANION_SD_CS_PIN, SPI, COMPANION_SD_SPI_FREQ)) {
+    return;
+  }
+
+  const uint8_t cardType = SD.cardType();
+  if (cardType == CARD_NONE) {
+    SD.end();
+    return;
+  }
+
+  const char* soundDir = COMPANION_SD_SOUND_DIR;
+  if (soundDir != nullptr && soundDir[0] == '/' && strlen(soundDir) > 1U && !SD.exists(soundDir)) {
+    (void)SD.mkdir(soundDir);
+  }
+
+  sdStorageReady_ = true;
+  sdStorageTotalBytes_ = SD.totalBytes();
+  sdStorageUsedBytes_ = SD.usedBytes();
+#endif
+#endif
 }
 
 bool LvglController::ensureConnected() {

--- a/receiver/esp32-companion/src/app/lvgl_controller.h
+++ b/receiver/esp32-companion/src/app/lvgl_controller.h
@@ -53,6 +53,9 @@ class LvglController {
   bool hasTxPowerReadback_ = false;
   uint8_t txPowerActiveDbm_ = 0;
   bool commandLockoutActive_ = false;
+  bool sdStorageReady_ = false;
+  uint64_t sdStorageTotalBytes_ = 0;
+  uint64_t sdStorageUsedBytes_ = 0;
 
   uint8_t buzzerDurationS_ = 3;
   bool buzzerConfigVisible_ = false;
@@ -161,6 +164,7 @@ class LvglController {
 
   void updateStaleness();
   void updateCompanionBattery();
+  void initSdStorage();
   bool ensureConnected();
 
   bool sendAction(const String& action, int durationS = 0);


### PR DESCRIPTION
- Add COMPANION_SD_ENABLE, COMPANION_SD_CS_PIN, COMPANION_SD_SPI_FREQ, COMPANION_SD_SOUND_DIR config options
- Implement initSdStorage() to mount SD card and create sound directory if configured
- Add sdStorageReady_, sdStorageTotalBytes_, sdStorageUsedBytes_ state tracking
- Update README with SD bootstrap configuration instructions