### PR TITLE
feat(esp32): add SD-backed WAV playback for flight event audio cues

### DIFF
--- a/receiver/esp32-companion/README.md
+++ b/receiver/esp32-companion/README.md
@@ -9,6 +9,7 @@ ground-station telemetry display.
 - UART-first companion transport to Pi ground station
 - Optional Wi-Fi API/SSE transport fallback
 - Optional Arduino OTA updates over Wi-Fi
+- Optional SD-backed WAV playback for key flight events (armed-waiting, liftoff, apogee, drogue, main, landing)
 - Telemetry dashboard:
   - Link status, RSSI, SNR, packet age
   - Flight phase, altitude AGL, vertical speed
@@ -54,6 +55,7 @@ cp include/config.h.example include/config.h
 - Wi-Fi + host settings if using API/SSE mode
 - auth token if `/api/companion/cmd` is protected
 - optional SD bootstrap (`COMPANION_SD_ENABLE`, `COMPANION_SD_CS_PIN`, `COMPANION_SD_SPI_FREQ`, `COMPANION_SD_SOUND_DIR`) for future sound assets
+- optional event audio output (`COMPANION_AUDIO_ENABLE`, `COMPANION_AUDIO_SPK_PIN`, `COMPANION_AUDIO_PWM_*`) and per-event WAV file paths (`COMPANION_SOUND_FILE_*`)
 - OTA settings (`OTA_ENABLE`, `OTA_HOSTNAME`, `OTA_PORT`, `OTA_PASSWORD`) if using OTA updates
 
 When `OTA_ENABLE=1`, firmware keeps Wi-Fi active even in UART transport mode so OTA

--- a/receiver/esp32-companion/include/config.h.example
+++ b/receiver/esp32-companion/include/config.h.example
@@ -69,6 +69,22 @@
 #define COMPANION_SD_SPI_FREQ 10000000
 #define COMPANION_SD_SOUND_DIR "/sounds"
 
+// Optional speaker playback for flight events using WAV files on SD.
+// Configure speaker pin/output and place matching WAV files on the card.
+// Elecrow CrowPanel 3.5 SPK header is driven from GPIO26 (DAC2/PWM-capable).
+#define COMPANION_AUDIO_ENABLE 1
+#define COMPANION_AUDIO_SPK_PIN 26
+#define COMPANION_AUDIO_PWM_CHANNEL 0
+#define COMPANION_AUDIO_PWM_FREQ 32000
+#define COMPANION_AUDIO_PWM_BITS 8
+
+#define COMPANION_SOUND_FILE_ARMED_WAIT "/sounds/armed_waiting.wav"
+#define COMPANION_SOUND_FILE_LIFTOFF "/sounds/liftoff.wav"
+#define COMPANION_SOUND_FILE_APOGEE "/sounds/apogee.wav"
+#define COMPANION_SOUND_FILE_DROGUE "/sounds/drogue_deploy.wav"
+#define COMPANION_SOUND_FILE_MAIN "/sounds/main_deploy.wav"
+#define COMPANION_SOUND_FILE_LANDING "/sounds/landing.wav"
+
 // OTA update settings.
 // When enabled, firmware keeps Wi-Fi active even in UART transport mode.
 // First flash should be done over USB, then OTA can be used for updates.

--- a/receiver/esp32-companion/src/app/lvgl_controller.cpp
+++ b/receiver/esp32-companion/src/app/lvgl_controller.cpp
@@ -98,6 +98,50 @@ static int32_t mapLinearRange(int32_t value,
 #define COMPANION_SD_SOUND_DIR "/sounds"
 #endif
 
+#ifndef COMPANION_AUDIO_ENABLE
+#define COMPANION_AUDIO_ENABLE 0
+#endif
+
+#ifndef COMPANION_AUDIO_SPK_PIN
+#define COMPANION_AUDIO_SPK_PIN -1
+#endif
+
+#ifndef COMPANION_AUDIO_PWM_CHANNEL
+#define COMPANION_AUDIO_PWM_CHANNEL 0
+#endif
+
+#ifndef COMPANION_AUDIO_PWM_FREQ
+#define COMPANION_AUDIO_PWM_FREQ 32000
+#endif
+
+#ifndef COMPANION_AUDIO_PWM_BITS
+#define COMPANION_AUDIO_PWM_BITS 8
+#endif
+
+#ifndef COMPANION_SOUND_FILE_ARMED_WAIT
+#define COMPANION_SOUND_FILE_ARMED_WAIT "/sounds/armed_waiting.wav"
+#endif
+
+#ifndef COMPANION_SOUND_FILE_LIFTOFF
+#define COMPANION_SOUND_FILE_LIFTOFF "/sounds/liftoff.wav"
+#endif
+
+#ifndef COMPANION_SOUND_FILE_APOGEE
+#define COMPANION_SOUND_FILE_APOGEE "/sounds/apogee.wav"
+#endif
+
+#ifndef COMPANION_SOUND_FILE_DROGUE
+#define COMPANION_SOUND_FILE_DROGUE "/sounds/drogue_deploy.wav"
+#endif
+
+#ifndef COMPANION_SOUND_FILE_MAIN
+#define COMPANION_SOUND_FILE_MAIN "/sounds/main_deploy.wav"
+#endif
+
+#ifndef COMPANION_SOUND_FILE_LANDING
+#define COMPANION_SOUND_FILE_LANDING "/sounds/landing.wav"
+#endif
+
 constexpr uint32_t kBatterySampleIntervalMs = COMPANION_BAT_SAMPLE_INTERVAL_MS;
 constexpr float kLipoCellEmptyV = 3.3f;
 constexpr float kLipoCellFullV = 4.2f;
@@ -143,6 +187,12 @@ static bool phaseIndicatesInFlight(const String& phaseText) {
   String phase = phaseText;
   phase.toLowerCase();
   return phase == "ascent" || phase == "descent" || phase == "boost" || phase == "coast";
+}
+
+static bool phaseEquals(const String& phaseText, const char* expectedLower) {
+  String phase = phaseText;
+  phase.toLowerCase();
+  return phase == expectedLower;
 }
 
 static lv_obj_t* makeActionButton(lv_obj_t* parent,
@@ -644,6 +694,7 @@ void LvglController::begin() {
   tft_.setRotation(1);
   tft_.fillScreen(TFT_BLACK);
   initSdStorage();
+  initSoundOutput();
 
 #if COMPANION_LINK_UART
   pinMode(COMPANION_BAT_ADC_PIN, INPUT);
@@ -757,6 +808,254 @@ void LvglController::initSdStorage() {
   sdStorageTotalBytes_ = SD.totalBytes();
   sdStorageUsedBytes_ = SD.usedBytes();
 #endif
+#endif
+}
+
+void LvglController::initSoundOutput() {
+  audioOutputReady_ = false;
+  audioPwmMaxDuty_ = 255;
+
+#if COMPANION_AUDIO_ENABLE
+#if COMPANION_AUDIO_SPK_PIN >= 0
+  const uint8_t pwmBits = (COMPANION_AUDIO_PWM_BITS > 15) ? 15 : COMPANION_AUDIO_PWM_BITS;
+  ledcSetup(COMPANION_AUDIO_PWM_CHANNEL, COMPANION_AUDIO_PWM_FREQ, pwmBits);
+  ledcAttachPin(COMPANION_AUDIO_SPK_PIN, COMPANION_AUDIO_PWM_CHANNEL);
+  const uint32_t maxDuty = (1UL << pwmBits) - 1UL;
+  audioPwmMaxDuty_ = static_cast<uint16_t>(maxDuty);
+  ledcWrite(COMPANION_AUDIO_PWM_CHANNEL, audioPwmMaxDuty_ / 2U);
+  audioOutputReady_ = true;
+#endif
+#endif
+}
+
+void LvglController::queueSoundCue(SoundCue cue) {
+  if (soundQueueCount_ >= kSoundQueueCapacity) {
+    return;
+  }
+
+  if (soundQueueCount_ > 0) {
+    const uint8_t lastIdx = static_cast<uint8_t>((soundQueueTail_ + kSoundQueueCapacity - 1) % kSoundQueueCapacity);
+    if (soundQueue_[lastIdx] == cue) {
+      return;
+    }
+  }
+
+  soundQueue_[soundQueueTail_] = cue;
+  soundQueueTail_ = static_cast<uint8_t>((soundQueueTail_ + 1) % kSoundQueueCapacity);
+  soundQueueCount_++;
+}
+
+const char* LvglController::cueFilePath(SoundCue cue) const {
+  switch (cue) {
+    case SoundCue::kArmedWait:
+      return COMPANION_SOUND_FILE_ARMED_WAIT;
+    case SoundCue::kLiftoff:
+      return COMPANION_SOUND_FILE_LIFTOFF;
+    case SoundCue::kApogee:
+      return COMPANION_SOUND_FILE_APOGEE;
+    case SoundCue::kDrogueDeploy:
+      return COMPANION_SOUND_FILE_DROGUE;
+    case SoundCue::kMainDeploy:
+      return COMPANION_SOUND_FILE_MAIN;
+    case SoundCue::kLanding:
+      return COMPANION_SOUND_FILE_LANDING;
+    default:
+      return "";
+  }
+}
+
+void LvglController::handleEventSoundTriggers(const String& previousPhase, bool phaseChanged) {
+  const String& currentPhase = state_.flight.phase;
+
+  if (phaseChanged) {
+    if (phaseEquals(currentPhase, "idle") && !phaseEquals(previousPhase, "idle")) {
+      queueSoundCue(SoundCue::kArmedWait);
+    }
+
+    const bool prevInAscent = phaseEquals(previousPhase, "ascent") || phaseEquals(previousPhase, "boost") ||
+                              phaseEquals(previousPhase, "coast");
+    const bool currInAscent = phaseEquals(currentPhase, "ascent") || phaseEquals(currentPhase, "boost") ||
+                              phaseEquals(currentPhase, "coast");
+
+    if (currInAscent && !prevInAscent) {
+      queueSoundCue(SoundCue::kLiftoff);
+    }
+
+    if (phaseEquals(currentPhase, "descent") && prevInAscent) {
+      queueSoundCue(SoundCue::kApogee);
+    }
+
+    if (phaseEquals(currentPhase, "landed") && !phaseEquals(previousPhase, "landed")) {
+      queueSoundCue(SoundCue::kLanding);
+    }
+  }
+
+  if (state_.hasRecoveryDeploymentState) {
+    if (hasRecoveryDeployHistory_) {
+      if (!lastRecoveryDrogueDeployed_ && state_.recoveryDrogueDeployed) {
+        queueSoundCue(SoundCue::kDrogueDeploy);
+      }
+      if (!lastRecoveryMainDeployed_ && state_.recoveryMainDeployed) {
+        queueSoundCue(SoundCue::kMainDeploy);
+      }
+    }
+    lastRecoveryDrogueDeployed_ = state_.recoveryDrogueDeployed;
+    lastRecoveryMainDeployed_ = state_.recoveryMainDeployed;
+    hasRecoveryDeployHistory_ = true;
+  }
+}
+
+void LvglController::playNextQueuedSound() {
+  if (soundQueueCount_ == 0) {
+    return;
+  }
+
+  const SoundCue cue = soundQueue_[soundQueueHead_];
+  soundQueueHead_ = static_cast<uint8_t>((soundQueueHead_ + 1) % kSoundQueueCapacity);
+  soundQueueCount_--;
+
+  (void)playWavFromSd(cueFilePath(cue));
+}
+
+bool LvglController::playWavFromSd(const char* path) {
+#if !COMPANION_AUDIO_ENABLE
+  (void)path;
+  return false;
+#else
+  if (!audioOutputReady_ || !sdStorageReady_ || path == nullptr || path[0] == '\0') {
+    return false;
+  }
+
+  File wav = SD.open(path, FILE_READ);
+  if (!wav || wav.isDirectory()) {
+    return false;
+  }
+
+  uint8_t riffHeader[12] = {0};
+  if (wav.read(riffHeader, sizeof(riffHeader)) != static_cast<int>(sizeof(riffHeader)) ||
+      memcmp(riffHeader, "RIFF", 4) != 0 || memcmp(riffHeader + 8, "WAVE", 4) != 0) {
+    wav.close();
+    return false;
+  }
+
+  uint16_t audioFormat = 0;
+  uint16_t numChannels = 0;
+  uint16_t bitsPerSample = 0;
+  uint32_t sampleRate = 0;
+  uint32_t dataOffset = 0;
+  uint32_t dataBytes = 0;
+
+  while (wav.available() >= 8) {
+    uint8_t chunkHeader[8] = {0};
+    if (wav.read(chunkHeader, sizeof(chunkHeader)) != static_cast<int>(sizeof(chunkHeader))) {
+      break;
+    }
+
+    const uint32_t chunkSize = static_cast<uint32_t>(chunkHeader[4]) |
+                               (static_cast<uint32_t>(chunkHeader[5]) << 8) |
+                               (static_cast<uint32_t>(chunkHeader[6]) << 16) |
+                               (static_cast<uint32_t>(chunkHeader[7]) << 24);
+    const uint32_t chunkDataPos = static_cast<uint32_t>(wav.position());
+
+    if (memcmp(chunkHeader, "fmt ", 4) == 0 && chunkSize >= 16) {
+      uint8_t fmt[16] = {0};
+      if (wav.read(fmt, sizeof(fmt)) != static_cast<int>(sizeof(fmt))) {
+        break;
+      }
+      audioFormat = static_cast<uint16_t>(fmt[0]) | (static_cast<uint16_t>(fmt[1]) << 8);
+      numChannels = static_cast<uint16_t>(fmt[2]) | (static_cast<uint16_t>(fmt[3]) << 8);
+      sampleRate = static_cast<uint32_t>(fmt[4]) |
+                   (static_cast<uint32_t>(fmt[5]) << 8) |
+                   (static_cast<uint32_t>(fmt[6]) << 16) |
+                   (static_cast<uint32_t>(fmt[7]) << 24);
+      bitsPerSample = static_cast<uint16_t>(fmt[14]) | (static_cast<uint16_t>(fmt[15]) << 8);
+    } else if (memcmp(chunkHeader, "data", 4) == 0) {
+      dataOffset = chunkDataPos;
+      dataBytes = chunkSize;
+    }
+
+    const uint32_t paddedSize = chunkSize + (chunkSize & 1U);
+    const uint32_t nextPos = chunkDataPos + paddedSize;
+    if (!wav.seek(nextPos)) {
+      break;
+    }
+  }
+
+  const bool formatOk = (audioFormat == 1U) && ((bitsPerSample == 8U) || (bitsPerSample == 16U)) &&
+                        (numChannels >= 1U) && (sampleRate > 0U) && (dataBytes > 0U);
+  if (!formatOk || !wav.seek(dataOffset)) {
+    wav.close();
+    return false;
+  }
+
+  const uint32_t bytesPerSample = (bitsPerSample / 8U) * static_cast<uint32_t>(numChannels);
+  if (bytesPerSample == 0U) {
+    wav.close();
+    return false;
+  }
+
+  uint32_t samplePeriodUs = 1000000UL / sampleRate;
+  if (samplePeriodUs == 0U) {
+    samplePeriodUs = 1U;
+  }
+
+  uint32_t bytesRemaining = dataBytes;
+  uint32_t nextSampleUs = micros();
+  bool readOk = true;
+  while (bytesRemaining >= bytesPerSample && readOk) {
+    int32_t mixed = 0;
+    for (uint16_t ch = 0; ch < numChannels; ++ch) {
+      int32_t sample = 0;
+      if (bitsPerSample == 8U) {
+        const int b = wav.read();
+        if (b < 0) {
+          readOk = false;
+          break;
+        }
+        sample = (static_cast<int32_t>(b) - 128) << 8;
+      } else {
+        const int lo = wav.read();
+        const int hi = wav.read();
+        if (lo < 0 || hi < 0) {
+          readOk = false;
+          break;
+        }
+        const uint16_t raw = static_cast<uint16_t>(static_cast<uint16_t>(hi) << 8) | static_cast<uint16_t>(lo);
+        sample = static_cast<int16_t>(raw);
+      }
+      mixed += sample;
+    }
+    if (!readOk) {
+      break;
+    }
+
+    if (numChannels > 1U) {
+      mixed /= static_cast<int32_t>(numChannels);
+    }
+
+    int32_t sampleU8 = (mixed + 32768) >> 8;
+    if (sampleU8 < 0) {
+      sampleU8 = 0;
+    } else if (sampleU8 > 255) {
+      sampleU8 = 255;
+    }
+
+    const uint32_t duty = (static_cast<uint32_t>(sampleU8) * audioPwmMaxDuty_) / 255U;
+    ledcWrite(COMPANION_AUDIO_PWM_CHANNEL, duty);
+
+    bytesRemaining -= bytesPerSample;
+    nextSampleUs += samplePeriodUs;
+    int32_t waitUs = static_cast<int32_t>(nextSampleUs - micros());
+    while (waitUs > 0) {
+      const uint32_t chunkUs = (waitUs > 200) ? 200U : static_cast<uint32_t>(waitUs);
+      delayMicroseconds(chunkUs);
+      waitUs = static_cast<int32_t>(nextSampleUs - micros());
+    }
+  }
+
+  ledcWrite(COMPANION_AUDIO_PWM_CHANNEL, audioPwmMaxDuty_ / 2U);
+  wav.close();
+  return readOk;
 #endif
 }
 
@@ -1452,7 +1751,11 @@ void LvglController::tick() {
 #endif
     syncCommandStateFromTelemetry();
 
-    if (state_.flight.phase != lastPhase_ && state_.flight.phase.length() > 0) {
+    const String previousPhase = lastPhase_;
+    const bool phaseChanged = (state_.flight.phase != previousPhase && state_.flight.phase.length() > 0);
+    handleEventSoundTriggers(previousPhase, phaseChanged);
+
+    if (phaseChanged) {
       setCommandStatus("Phase -> " + state_.flight.phase, true);
       lastPhase_ = state_.flight.phase;
     }
@@ -1466,6 +1769,7 @@ void LvglController::tick() {
   handleCalibrationTouch();
   updatePendingCommandTimeouts(now);
   updateStaleness();
+  playNextQueuedSound();
 
   const bool statusVisible = cmdMsg_.length() > 0 && (now - cmdTs_) <= kCommandStatusShowMs;
   if (updated || statusVisible || (now - lastUiRefreshMs_) >= kUiRefreshIntervalMs) {

--- a/receiver/esp32-companion/src/app/lvgl_controller.h
+++ b/receiver/esp32-companion/src/app/lvgl_controller.h
@@ -19,6 +19,15 @@ class LvglController {
   void tick();
 
  private:
+  enum class SoundCue : uint8_t {
+    kArmedWait = 0,
+    kLiftoff,
+    kApogee,
+    kDrogueDeploy,
+    kMainDeploy,
+    kLanding,
+  };
+
   struct TouchCalibration {
     int32_t xMin = TOUCH_X_MIN;
     int32_t xMax = TOUCH_X_MAX;
@@ -56,6 +65,16 @@ class LvglController {
   bool sdStorageReady_ = false;
   uint64_t sdStorageTotalBytes_ = 0;
   uint64_t sdStorageUsedBytes_ = 0;
+  bool audioOutputReady_ = false;
+  uint16_t audioPwmMaxDuty_ = 255;
+  bool hasRecoveryDeployHistory_ = false;
+  bool lastRecoveryDrogueDeployed_ = false;
+  bool lastRecoveryMainDeployed_ = false;
+  static constexpr uint8_t kSoundQueueCapacity = 8;
+  SoundCue soundQueue_[kSoundQueueCapacity] = {};
+  uint8_t soundQueueHead_ = 0;
+  uint8_t soundQueueTail_ = 0;
+  uint8_t soundQueueCount_ = 0;
 
   uint8_t buzzerDurationS_ = 3;
   bool buzzerConfigVisible_ = false;
@@ -165,6 +184,12 @@ class LvglController {
   void updateStaleness();
   void updateCompanionBattery();
   void initSdStorage();
+  void initSoundOutput();
+  void queueSoundCue(SoundCue cue);
+  void handleEventSoundTriggers(const String& previousPhase, bool phaseChanged);
+  void playNextQueuedSound();
+  const char* cueFilePath(SoundCue cue) const;
+  bool playWavFromSd(const char* path);
   bool ensureConnected();
 
   bool sendAction(const String& action, int durationS = 0);

--- a/receiver/esp32-companion/src/model/telemetry_state.h
+++ b/receiver/esp32-companion/src/model/telemetry_state.h
@@ -48,6 +48,9 @@ struct CompanionState {
   uint8_t telemetryTxPowerDbm = 0;
   bool hasCommandLockoutState = false;
   bool commandLockoutActive = false;
+  bool hasRecoveryDeploymentState = false;
+  bool recoveryDrogueDeployed = false;
+  bool recoveryMainDeployed = false;
   String primaryAlert;
   bool stale = true;
 };

--- a/receiver/esp32-companion/src/net/api_client.cpp
+++ b/receiver/esp32-companion/src/net/api_client.cpp
@@ -179,6 +179,19 @@ bool ApiClient::applyStateJson(const String& jsonPayload, CompanionState& ioStat
   ioState.alt.gpsAltitudeM = gpsAlt;
   ioState.alt.verticalSpeedMps = recovery["vertical_speed_mps"].isNull() ? NAN : (float)recovery["vertical_speed_mps"].as<float>();
 
+  JsonObject recoveryDrogue = recovery["drogue"];
+  JsonObject recoveryMain = recovery["main"];
+  if (!recoveryDrogue.isNull() && !recoveryMain.isNull() &&
+      !recoveryDrogue["deployed"].isNull() && !recoveryMain["deployed"].isNull()) {
+    ioState.hasRecoveryDeploymentState = true;
+    ioState.recoveryDrogueDeployed = recoveryDrogue["deployed"].as<bool>();
+    ioState.recoveryMainDeployed = recoveryMain["deployed"].as<bool>();
+  } else {
+    ioState.hasRecoveryDeploymentState = false;
+    ioState.recoveryDrogueDeployed = false;
+    ioState.recoveryMainDeployed = false;
+  }
+
   JsonObject battery = state["battery"];
   ioState.battery.telemetryVbatV =
       battery["vbat_v"].isNull() ? NAN : (float)battery["vbat_v"].as<float>();

--- a/receiver/esp32-companion/src/serial/uart_link.cpp
+++ b/receiver/esp32-companion/src/serial/uart_link.cpp
@@ -49,6 +49,9 @@ void UartLink::applyTelemetry(const TelemetryV1& t, bool hasTxPower, CompanionSt
   ioState.telemetryTxPowerDbm = txPowerValid ? t.telemetry_tx_power_dbm : 0;
   ioState.hasCommandLockoutState = true;
   ioState.commandLockoutActive = (t.flags & 0x20) != 0;
+  ioState.hasRecoveryDeploymentState = true;
+  ioState.recoveryDrogueDeployed = (t.flags & 0x02) != 0;
+  ioState.recoveryMainDeployed = (t.flags & 0x04) != 0;
 
   ioState.stale = false;
 }
@@ -106,6 +109,9 @@ bool UartLink::poll(CompanionState& ioState) {
         ioState.telemetryTxPowerDbm = 0;
         ioState.hasCommandLockoutState = true;
         ioState.commandLockoutActive = (t.flags & 0x20) != 0;
+        ioState.hasRecoveryDeploymentState = true;
+        ioState.recoveryDrogueDeployed = (t.flags & 0x02) != 0;
+        ioState.recoveryMainDeployed = (t.flags & 0x04) != 0;
 
         ioState.stale = false;
         updated = true;


### PR DESCRIPTION
- Add COMPANION_AUDIO_ENABLE, COMPANION_AUDIO_SPK_PIN, COMPANION_AUDIO_PWM_* config options
- Add COMPANION_SOUND_FILE_* config paths for armed-waiting, liftoff, apogee, drogue, main, landing events
- Implement initSoundOutput() to configure PWM audio output on speaker pin
- Add SoundCue enum and sound queue with 8-slot circular buffer
- Implement queueSoundCue() to enqueue events and deduplicate consecutive cues
- Add handleEventSoundTriggers() to